### PR TITLE
fix "active" setting & toggles

### DIFF
--- a/src/copilot.ts
+++ b/src/copilot.ts
@@ -13,16 +13,6 @@ export interface GetCopilotStateOptions extends Pick<CopilotStateOptions, 'scope
   config?: WorkspaceConfiguration
 }
 
-function getValue(languageId: string): unknown {
-  const record = workspace.getConfiguration('github.copilot').get('enable')
-  if (typeof record === 'object' && record !== null) {
-    if (languageId in record) {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expression o...
-      return record[languageId]
-    }
-  }
-}
-
 export function getCopilotConfigState({ scope, config }: GetCopilotStateOptions = {}) {
   const usingConfig = config ? config : workspace.getConfiguration('github.copilot', scope)
   const languageId = scope && 'languageId' in scope ? scope.languageId : null

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,6 +177,9 @@ export class Manager {
 
     return [
       commands.registerCommand(`${this.extensionId}.addScopes`, this.onAddScopesCommand, this),
+      commands.registerCommand(`${this.extensionId}.toggle`, this.toggle, this),
+      commands.registerCommand(`${this.extensionId}.enable`, this.enable, this),
+      commands.registerCommand(`${this.extensionId}.disable`, this.disable, this),
       workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this),
       /* window.onDidChangeActiveTextEditor((event) => {
         if (!event) {
@@ -358,6 +361,25 @@ export class Manager {
     })
 
     return await workspace.getConfiguration(this.extensionId).update(`textMateRules`, finalRules)
+  }
+
+  private toggle() {
+    const currentState = this.configuration.active
+    return workspace
+      .getConfiguration(this.extensionId)
+      .update(`active`, !currentState, ConfigurationTarget.Global)
+  }
+
+  private enable() {
+    return workspace
+      .getConfiguration(this.extensionId)
+      .update(`active`, true, ConfigurationTarget.Global)
+  }
+
+  private disable() {
+    return workspace
+      .getConfiguration(this.extensionId)
+      .update(`active`, false, ConfigurationTarget.Global)
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,7 @@ export class Manager {
     const inhibitMatchers = untypedConfig.get(`inhibitMatchers`)
     if (inhibitMatchers === undefined) return
 
-    const promises = [untypedConfig.update(`inhibitMatchers`, undefined, true)]
+    const promises = [ untypedConfig.update(`inhibitMatchers`, undefined, true) ]
 
     if (Array.isArray(inhibitMatchers)) {
       const textMateRules = inhibitMatchers.reduce((acc: Array<MatchRule>, value) => {
@@ -88,7 +88,7 @@ export class Manager {
       }, [])
 
       if (textMateRules.length > 0) {
-        const newRules = [...Manager.configuration.textMateRules, ...textMateRules].reduce(
+        const newRules = [ ...Manager.configuration.textMateRules, ...textMateRules ].reduce(
           (acc: MatchRule[], rule, index, array) => {
             const otherRules = array.slice(index + 1)
             if (!otherRules.some((otherRule) => areRulesEquivalent(rule, otherRule))) {
@@ -316,7 +316,7 @@ export class Manager {
       )
 
     const { document, selection } = editor
-    const caretScopes = [...new Set(this.hscopes.getScopeAt(document, selection.active)?.scopes ?? [])]
+    const caretScopes = [ ...new Set(this.hscopes.getScopeAt(document, selection.active)?.scopes ?? []) ]
     if (!caretScopes.length) return await window.showErrorMessage(`No scopes found at the current selection.`)
 
     const { regexp, string } = this.configuration.textMateRules.reduce(
@@ -336,7 +336,7 @@ export class Manager {
 
     const stringRulesNotAtCaret = string.filter((item) => item.type === 'string' && !caretScopes.includes(item.value))
     const stringRulesAtCaret = string.filter((item) => item.type === 'string' && caretScopes.includes(item.value))
-    const finalRules = [...regexp, ...stringRulesNotAtCaret]
+    const finalRules = [ ...regexp, ...stringRulesNotAtCaret ]
 
     const quickPickItems = caretScopes.map(
       (scope): QuickPickItem => ({
@@ -469,6 +469,12 @@ export class Manager {
     scope: ConfigurationScope | undefined | null
   ): Promise<void> {
     const log = this.createLogger('updateCopilotState')
+    if (!Manager.configuration.active) {
+      log(`Extension is inactive, skipping updateCopilotState call.`)
+      this.statusBarItem.tooltip  = `GH Copilot Suggestions (Extension Inactive)`
+      this.statusBarItem.text = `Suggestions Toggling Inactive`
+      return
+    }
     log(`Setting Copilot Inline Suggestions to: ${state}, Reason: ${reason}`)
 
     this.statusBarItem.tooltip = state


### PR DESCRIPTION
Hello! Thanks for responding quickly on my PR. Here's the combined version of all of the above.

1. read the "active" setting in `updateCopilotState`, and bail out early if it's true. I also update the statusbar icon, which updates the next time it would have changed states.
<img width="257" height="65" alt="image" src="https://github.com/user-attachments/assets/03551d17-defc-492a-9466-0d1e51c670e0" />

2. add commands for enable, disable, and toggle, which just edit the "active" setting in settings.json.

3. remove an unused function that was having type errors on the latest `tsx`

## Reproduction

1. set `"disable-copilot-comment-completions.active": false` in your settings.json
2. move your cursor inside a comment
3. move your cursor outside a comment

Before, it would turn it on inside the comment and off outside the comment. Now, it leaves copilot in whatever state it was (enabled, disabled).

Happy to any changes!
